### PR TITLE
fix security context

### DIFF
--- a/helm/sealed-secrets/values.yaml
+++ b/helm/sealed-secrets/values.yaml
@@ -164,6 +164,7 @@ containerSecurityContext:
   enabled: true
   readOnlyRootFilesystem: true
   runAsNonRoot: true
+  allowPrivilegeEscalation: false
   runAsUser: 1001
   capabilities:
     drop:


### PR DESCRIPTION
This PR sets `allowPrivilegeEscalation` to false by default to improve security.
